### PR TITLE
Store error message also for basic result codes.

### DIFF
--- a/hdr/sqlite_modern_cpp/errors.h
+++ b/hdr/sqlite_modern_cpp/errors.h
@@ -48,7 +48,7 @@ namespace sqlite {
 				case SQLITE_ ## NAME: switch(error_code) {          \
 					derived                                           \
 					case SQLITE_ ## NAME:                             \
-					default: throw name(error_code, sql);             \
+					default: throw name(error_code, sql, errmsg);     \
 				}
 
 #if SQLITE_VERSION_NUMBER < 3010000


### PR DESCRIPTION
While `throw_sqlite_error` is called with the return value of `sqlite3_errmsg` everywhere, `throw_sqlite_error` uses this argument only for extended result codes, and discards it for basic ones. ced361fec35623863b24775b715b474f0b6b9cae must have left that out by accident.